### PR TITLE
Remove provider parameter from earthaccess.get_s3fs_session call

### DIFF
--- a/book/tutorials/data-access-and-format/icepyx.ipynb
+++ b/book/tutorials/data-access-and-format/icepyx.ipynb
@@ -813,7 +813,7 @@
    },
    "outputs": [],
    "source": [
-    "s3 = earthaccess.get_s3fs_session(daac='NSIDC', provider=result._s3login_credentials)  # Start a S3 session - can we use earthaccess.open here"
+    "s3 = earthaccess.get_s3fs_session(daac='NSIDC')  # Start a S3 session - can we use earthaccess.open here"
    ]
   },
   {


### PR DESCRIPTION
Fix `TypeError: unhashable type: 'dict'`

Reported by @ShashankBice