### PR TITLE
GH actions - Update code spell

### DIFF
--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -31,9 +31,9 @@ jobs:
       uses: codespell-project/actions-codespell@v2
       with:
         check_filenames: true
-        check_hidden: false
-        skip: '*.js,qaqc.yml,acp_lidar_box.geojson,.codespellignore'
+        skip: '*.js,qaqc.yml,acp_lidar_box.geojson'
         ignore_words_file: .codespellignore
+        only_warn: 1
 
     # borrowed from https://github.com/ProjectPythia/pythia-foundations/blob/main/.github/workflows/link-checker.yaml
     - name: Disable Notebook Execution Before Linkcheck


### PR DESCRIPTION
To ignore hidden files, the configuration option needs to be removed as it is the default behavior. Also changing to only return a warning instead of an error.

This might help getting #86 to merge, only returning a warning