### PR TITLE
Splashpage - Fix auto-selection of current schedule day

### DIFF
--- a/{{ cookiecutter.repo_directory }}/assets/js/main.js
+++ b/{{ cookiecutter.repo_directory }}/assets/js/main.js
@@ -119,7 +119,7 @@ function today(){
   const today = new Date();
   const weekday = new Intl.DateTimeFormat('en', { weekday: 'long' }).format(today);
   const month = new Intl.DateTimeFormat('en', { month: 'long' }).format(today);
-  const day = new Intl.DateTimeFormat('en', { day: 'numeric' }).format(today);
+  const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(today);
 
   return [weekday, day, month].join(' ')
 }


### PR DESCRIPTION
Small feature that broke recently when we switched to use the automatic schedule `yaml` creation as it uses a two-digit day.